### PR TITLE
Add positioning section, drop em dashes and arrows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,5 +20,4 @@ labels: bug
 - Node version:
 
 **Generated SQL (if relevant)**
-If you can, capture the SQL the ORM emitted (e.g. by logging in your provider)
-— wrong-SQL bugs are fixed much faster with the actual statement.
+If you can, capture the SQL the ORM emitted (e.g. by logging in your provider). Wrong-SQL bugs are fixed much faster with the actual statement.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -14,7 +14,7 @@ What can't you do today, or what is painful?
 ```
 
 **How EF Core (or another ORM) handles this**
-rnxORM follows EF Core's model where sensible — prior art helps scope the design.
+rnxORM follows EF Core's model where sensible. Prior art helps scope the design.
 
 **Scope notes**
 Current provider focus is SQL Server + PostgreSQL (see issues #8/#12 for the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ Closes #
 ## Docs
 
 - [ ] README / CHANGELOG updated if behavior or claims changed
-      (README claims must stay evidence-based — link the proving test)
+      (README claims must stay evidence-based. Link the proving test)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
       # NOTE: no registry-url here. Setting it makes setup-node write an
       # .npmrc with an _authToken placeholder, which npm prefers over the
-      # OIDC exchange — the publish then 403s. Trusted publishing needs the
+      # OIDC exchange. The publish then 403s. Trusted publishing needs the
       # default registry with NO token configured.
       # Node 22: staged publishing requires Node >= 22.14 / npm >= 11.15.
       - name: Use Node.js 22.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,19 @@
   column spelling; renamed properties resolve to their mapped column) and the
   operator against a closed set (`=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`,
   `LIKE`, `ILIKE`, `NOT LIKE`, `IN`, `NOT IN`, `IS`, `IS NOT`). Structured
-  query-filter operators pass through the same set. Injected strings —
-  including the `orderBy(req.query.sort)` pattern — now throw before any SQL is
+  query-filter operators pass through the same set. Injected strings , 
+  including the `orderBy(req.query.sort)` pattern. Now throw before any SQL is
   assembled. Previously column and operator were interpolated verbatim. Added
   `SECURITY.md` documenting the protection boundary.
   Grouped `orderBy()` is the one documented exception: it also accepts a
   projection alias that exists only in the SELECT list, which metadata cannot
-  verify, so such aliases are required to be plain identifiers — which still
+  verify, so such aliases are required to be plain identifiers. Which still
   rejects every injection-shaped string (quotes, whitespace, semicolons,
   comment markers).
 - **`skip()` / `take()` validate their argument.** Row limits are the only
   query-API arguments that must be interpolated into SQL (`LIMIT`/`OFFSET` and
   `OFFSET ... FETCH NEXT` take no bound parameter on every driver), and
-  TypeScript's `number` type erases at runtime — an `as any` cast or an untyped
+  TypeScript's `number` type erases at runtime. An `as any` cast or an untyped
   `req.query.limit` used to land verbatim in the statement
   (`take("10; DELETE FROM users --")` emitted the payload). All four builders
   now require a non-negative integer and throw before any SQL is assembled.
@@ -50,7 +50,7 @@
   correctly on every dialect. Passing a non-array to `IN`, or a non-null value
   to `IS`, throws.
 - **Eager-loaded entities are change-tracked and identity-mapped.** See
-  Changed — `include()` previously returned untracked, unmapped copies.
+  Changed. `include()` previously returned untracked, unmapped copies.
 - **Query-filter operators are validated at registration time.**
   `ModelBuilder.hasQueryFilter()` (structured form) checks each condition's
   operator when `onModelCreating()` runs, so a configuration typo fails once at
@@ -64,7 +64,7 @@
   ahead of GROUP BY/HAVING with placeholder ordering preserved;
   `ignoreQueryFilters()` respected. Caveat: because `having()` bakes its
   placeholder indices from the parameter count at call time, grouped queries
-  must inject the filter first — so a **function-valued** filter value is
+  must inject the filter first. So a **function-valued** filter value is
   resolved when `groupBy()` is called, not when the query executes. Every other
   read path resolves it at execution. Build grouped queries after the value
   (e.g. the current tenant) is in place.
@@ -74,12 +74,12 @@
 
 ### Changed
 
-- **Operators outside the supported set now throw** — breaking for
+- **Operators outside the supported set now throw**. Breaking for
   *documented* 2.1 usage, not just undefined behavior: 2.1's README showed
   arbitrary SQL comparison operators. The closed set now covers everything
   that was realistically in use (`IN`/`NOT IN`/`IS`/`IS NOT` are restored
   above), leaving `BETWEEN` as the one documented operator with no
-  replacement — express it as two `where()` calls
+  replacement. Express it as two `where()` calls
   (`.where('age','>=',18).where('age','<=',65)`).
 - `where()`/`orderBy()`/`having()` now **throw** on unmapped columns instead of
   emitting them into SQL. Code passing invalid identifiers was generating
@@ -93,7 +93,7 @@
   column selector (`g.sum()`) throws too, where it previously rendered
   `SUM(undefined)` into the statement.
 - **`g.key` now aliases the group column.** A selector containing `g.key`
-  emits `<group column> AS <alias>` — so `select(g => ({ dept: g.key, ... }))`
+  emits `<group column> AS <alias>`. So `select(g => ({ dept: g.key, ... }))`
   changes both the emitted SQL and the result-row keys (previously the bare
   group column was emitted and rows came back keyed by the column name, e.g.
   `department`, not `dept`). Selectors that never reference `g.key` keep their
@@ -121,20 +121,20 @@
   `SELECT *` plus in-memory projection (correct results, full rows fetched),
   and APIs with no fallback (`include`, `sum`, `average`, `min`, `max`,
   `groupBy` aggregates) throw. Previously the first column reached silently
-  became the whole expression. `capture()` now evaluates the selector twice —
+  became the whole expression. `capture()` now evaluates the selector twice , 
   a second "nullish probe" pass is the only way to observe a short-circuited
-  operand — so selectors must be pure.
+  operand. So selectors must be pure.
 
 ### Added (from the earlier unreleased 2.2.0 work)
 
 - **SQL-translated global query filters.** `hasQueryFilter()` now accepts
-  structured conditions — `{ property, operator, value }` or an array of them —
+  structured conditions. `{ property, operator, value }` or an array of them , 
   that are compiled into parameterized SQL `WHERE` clauses on every query path
   (`toList()`, `find()`, `where()` chains, `count`/`sum`/`average`/`min`/`max`,
   and `select()` projections), so filtered rows never leave the database.
   `operator` must come from the same validated set as `where()` (see Security),
   `value` may be a function resolved at query time (e.g. a current tenant id),
-  and value converters are applied — per element for `IN`/`NOT IN`. The
+  and value converters are applied. Per element for `IN`/`NOT IN`. The
   predicate form remains supported and
   still runs in memory. Raw SQL results are now filtered in memory by both
   forms. `DbSet` gained `ignoreQueryFilters()` for parity with query chains.
@@ -161,7 +161,7 @@
 ### Documentation
 
 - **The README is now evidence-based.** The Features section carries a
-  feature→test verification map linking every implemented claim to the test
+  feature-to-test verification map linking every implemented claim to the test
   suite that proves it. Claims that had no automated evidence got tests
   (`asNoTracking`, `saveChanges` transaction wrapping and rollback,
   `executeSqlRaw`, shadow-column inserts, schema evolution, the provider
@@ -199,7 +199,7 @@
 Stabilization release: the suite now runs against real PostgreSQL 16, MariaDB 11,
 and SQL Server 2022 (via `docker-compose.test.yml` / `npm run test:integration`),
 and the documentation was rewritten to state feature status honestly
-(implemented / partial / planned) — see the Features section of the README.
+(implemented / partial / planned). See the Features section of the README.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
 # rnxORM
 
-A lightweight TypeScript ORM for **PostgreSQL**, **SQL Server**, and **MariaDB**, inspired by Entity Framework Core.
+Entity Framework Core's programming model, in TypeScript. For **SQL Server** and **PostgreSQL**.
 
 [![npm version](https://img.shields.io/npm/v/rnxorm.svg)](https://www.npmjs.com/package/rnxorm)
 [![GitHub](https://img.shields.io/badge/github-BaryoDev%2FrnxORM-blue)](https://github.com/BaryoDev/rnxORM)
 [![CI](https://github.com/BaryoDev/rnxORM/actions/workflows/ci.yml/badge.svg)](https://github.com/BaryoDev/rnxORM/actions/workflows/ci.yml)
 [![Integration (real databases)](https://github.com/BaryoDev/rnxORM/actions/workflows/integration.yml/badge.svg)](https://github.com/BaryoDev/rnxORM/actions/workflows/integration.yml)
 [![Ko-fi](https://img.shields.io/badge/Support%20me%20on-Ko--fi-ff5f5f?logo=ko-fi&logoColor=white)](https://ko-fi.com/T6T01CQT4R)
+
+## Who this is for
+
+If you have written EF Core and now write TypeScript, your knowledge transfers here directly. `DbContext`, `DbSet`, `saveChanges`, `include`, `asNoTracking`, query filters, value converters, shadow properties and concurrency tokens all keep the names and the behaviour you already know.
+
+That is the whole idea. It is not a general recommendation over the popular TypeScript ORMs, and it would be dishonest to pretend otherwise.
+
+**How it differs from Drizzle, Kysely and Prisma.** Those are SQL-first: you write queries that read like SQL and you write your inserts and updates explicitly. There is no change tracker and no identity map, by design. rnxORM is object-first: load a graph, change it across several methods, call `saveChanges()`, and let the tracker work out the difference. Different model, different user. If the SQL-first approach suits you, they are excellent and far more mature.
+
+**How it differs from MikroORM.** It largely does not. MikroORM has the same unit of work, identity map and change tracking, is well maintained, and supports more databases. It speaks Doctrine's vocabulary: `EntityManager`, `em.flush()`, `wrap()`, `populate`. rnxORM speaks EF Core's. If that vocabulary is not worth anything to you, MikroORM is the more established choice and you should use it.
+
+**One thing no ORM can do.** TypeScript erases types and cannot overload operators, so `where(u => u.age > 18)` is not achievable without a compiler transform. Expression-tree translation is a C# feature, not a TypeScript one. Queries here use a typed builder, which is the same conclusion Drizzle and Kysely reached.
+
+## Database support
+
+| Database | Status |
+|---|---|
+| **SQL Server** | Focus. The alternatives are weakest here; Drizzle has no support at all. |
+| **PostgreSQL** | Focus. |
+| MariaDB | Maintained, not developed. Works and keeps its tests; new features land here only if they fall out for free. |
+| SQLite | Test substrate. Not a shipped provider. |
+| MySQL | Deferred. See [#8](https://github.com/BaryoDev/rnxORM/issues/8) for the reasoning. |
+
+Two providers done properly is a better use of one maintainer than five done thinly.
 
 ## Installation
 
@@ -44,7 +68,7 @@ Ensure you have `experimentalDecorators` and `emitDecoratorMetadata` enabled in 
 ## Usage
 
 > **Runnable examples**: [`examples/`](examples/) contains five self-contained
-> demos verified against real PostgreSQL — quickstart CRUD, relationships and
+> demos verified against real PostgreSQL. Quickstart CRUD, relationships and
 > eager loading, query filters + the injection-rejection showcase, identity
 > map + optimistic concurrency, and migrations. Each prints labeled output
 > and cleans up after itself; see [`examples/README.md`](examples/README.md).
@@ -165,7 +189,7 @@ This library is designed to be AI-friendly. If you are an AI agent, you can read
 
 Feature status is marked honestly: ✅ implemented, ⚠️ partial (works with documented limitations), ❌ planned (API may exist but is not functional yet).
 
-Every ✅ and ⚠️ claim is **evidence-based**: it is backed by automated tests in this repository — see the [feature verification map](#feature-verification) below for exactly which test suite proves each claim, and [Testing status](#testing-status) for how the suite runs against real databases in CI.
+Every ✅ and ⚠️ claim is **evidence-based**: it is backed by automated tests in this repository. See the [feature verification map](#feature-verification) below for exactly which test suite proves each claim, and [Testing status](#testing-status) for how the suite runs against real databases in CI.
 
 ### Implemented ✅
 
@@ -176,7 +200,7 @@ Every ✅ and ⚠️ claim is **evidence-based**: it is backed by automated test
 - **Data Seeding**: Idempotent seeding via `hasData()` in ModelBuilder
 - **Decorators**: `@Entity`, `@Column`, `@PrimaryKey`, `@Index`, `@Unique`
 - **Relationships**: `@ManyToOne`, `@OneToMany`, `@ManyToMany`, `@OneToOne` with foreign key and join table scaffolding
-- **Eager Loading**: `.include()` loads related entities via batched follow-up queries (`WHERE pk IN (...)`), not JOINs. Single-level only — no nested `thenInclude`
+- **Eager Loading**: `.include()` loads related entities via batched follow-up queries (`WHERE pk IN (...)`), not JOINs. Single-level only. No nested `thenInclude`
 - **Value Converters**: `hasConversion()` applied on both read and write paths
 - **Schema Scaffolding**: `ensureCreated()` creates tables, foreign keys, indexes, and constraints
 - **Schema Evolution**: `ensureCreated()` adds missing columns and attempts safe type migrations (best-effort; incompatible data leaves the column unchanged)
@@ -190,23 +214,23 @@ Every ✅ and ⚠️ claim is **evidence-based**: it is backed by automated test
 - **Query Optimization**: `.asNoTracking()` skips change tracking for read-only queries
 - **Primary Key Lookup**: `.find(id)`
 - **Global Query Filters (structured form)**: `hasQueryFilter({ property, operator, value })` conditions are **translated to SQL WHERE clauses** on every query path (`toList`, `find`, `where()` chains, aggregates, projections, `groupBy()`), so filtered rows never leave the database. Bypass per-query with `ignoreQueryFilters()`. See [Global Query Filters](#global-query-filters)
-- **Identifier & operator validation**: `where()`/`orderBy()`/`having()` and query-filter conditions validate column names against entity metadata and operators against a closed set at runtime — injected strings throw before SQL is assembled. See [Query Operators](#query-operators) and [SECURITY.md](SECURITY.md)
+- **Identifier & operator validation**: `where()`/`orderBy()`/`having()` and query-filter conditions validate column names against entity metadata and operators against a closed set at runtime. Injected strings throw before SQL is assembled. See [Query Operators](#query-operators) and [SECURITY.md](SECURITY.md)
 - **Identity map**: loading the same row twice returns the **same tracked instance** (keyed by entity type + primary key), so re-queries can't create conflicting tracked copies and local unsaved modifications survive a re-query. This covers rows loaded through `find()`/`toList()`/`where()` chains, entities eagerly loaded with `include()`, and entities that entered tracking with a known key via `attach()`/`update()`/`add()`. `asNoTracking()` results are never identity-mapped, and neither are primary keys whose value converter produces a non-primitive (the map compares keys by value, so a fresh object per row never matches)
 - **Selector capture (no regex parsing)**: lambda selectors (`include`, aggregates, `select`, `groupBy`, ModelBuilder, decorators) are resolved by a recording Proxy; nested paths and computed expressions fail loudly instead of silently resolving to a wrong column
-- **Migration CLI**: `npx rnxorm migration:create|run|revert|status` — run/revert/status load a `rnxorm.config.js` exporting a `createMigrator()` factory. See [Migrations](#migrations)
+- **Migration CLI**: `npx rnxorm migration:create|run|revert|status`. Run/revert/status load a `rnxorm.config.js` exporting a `createMigrator()` factory. See [Migrations](#migrations)
 
 ### Partial ⚠️
 
-- **LINQ-Style Projections (`select`, `groupBy`)**: Lambda selectors are resolved by a recording Proxy (`src/core/expressions/PropertyCapture.ts`) — TypeScript has no expression trees, so this is capture, not parsing. Simple shapes (`u => ({ name: u.name })`, `g.count()`, `g.sum(u => u.prop)`, `g.key`) translate to SQL with mapped column names; a projected property that is not a mapped column **throws**; computed selectors (template strings, arithmetic) fall back to fetching rows and projecting in memory. Nested paths (`u => u.address.city`) throw instead of silently resolving to the wrong column. See [LINQ-Style Query API](#linq-style-query-api)
-- **Global Query Filters (predicate form)**: the legacy `hasQueryFilter(u => ...)` predicate form runs **in memory after rows are fetched** — it is never translated to SQL. Prefer the structured-condition form, which is. See [Global Query Filters](#global-query-filters)
-- **Raw SQL Queries**: `fromSqlRaw()`/`executeSqlRaw()` work, but parameter placeholders are **not** translated between dialects — write `$1` for PostgreSQL, `@p0` for SQL Server, `?` for MariaDB. Global query filters on raw SQL results are evaluated in memory
+- **LINQ-Style Projections (`select`, `groupBy`)**: Lambda selectors are resolved by a recording Proxy (`src/core/expressions/PropertyCapture.ts`). TypeScript has no expression trees, so this is capture, not parsing. Simple shapes (`u => ({ name: u.name })`, `g.count()`, `g.sum(u => u.prop)`, `g.key`) translate to SQL with mapped column names; a projected property that is not a mapped column **throws**; computed selectors (template strings, arithmetic) fall back to fetching rows and projecting in memory. Nested paths (`u => u.address.city`) throw instead of silently resolving to the wrong column. See [LINQ-Style Query API](#linq-style-query-api)
+- **Global Query Filters (predicate form)**: the legacy `hasQueryFilter(u => ...)` predicate form runs **in memory after rows are fetched**. It is never translated to SQL. Prefer the structured-condition form, which is. See [Global Query Filters](#global-query-filters)
+- **Raw SQL Queries**: `fromSqlRaw()`/`executeSqlRaw()` work, but parameter placeholders are **not** translated between dialects. Write `$1` for PostgreSQL, `@p0` for SQL Server, `?` for MariaDB. Global query filters on raw SQL results are evaluated in memory
 - **Keyless Entity Types**: `hasNoKey()` works for querying views; read-only behavior is not enforced (no error if you try to track one)
-- **Shadow Properties**: Columns are created and included in INSERTs, but defaults are sent as literal parameter values — SQL expressions like `CURRENT_TIMESTAMP` are **not** emitted as DDL `DEFAULT` clauses and will not evaluate. Use constant defaults only
+- **Shadow Properties**: Columns are created and included in INSERTs, but defaults are sent as literal parameter values. SQL expressions like `CURRENT_TIMESTAMP` are **not** emitted as DDL `DEFAULT` clauses and will not evaluate. Use constant defaults only
 
-### Planned ❌ (API exists but is not functional — do not rely on these)
+### Planned ❌ (API exists but is not functional. Do not rely on these)
 
 - **Explicit Loading**: `entry().reference()`/`collection()` throw "not implemented"
-- **Owned Entity Types**: `ownsOne()`/`ownsMany()` store configuration but nothing consumes it — no column flattening, no owned tables are created
+- **Owned Entity Types**: `ownsOne()`/`ownsMany()` store configuration but nothing consumes it. No column flattening, no owned tables are created
 - **Default Values**: `hasDefaultValue()` on regular columns stores metadata but is never emitted to DDL or used in inserts
 - **Computed Columns**: `hasComputedColumnSql()` stores metadata but no `GENERATED ALWAYS AS` DDL is emitted
 - **Lazy Loading**: Not implemented
@@ -245,14 +269,14 @@ Each implemented feature maps to the automated tests that prove it. Unit suites 
 | Selector capture (Proxy, nested/computed classification, aggregates, `g.key`) | `test/unit/PropertyCapture.test.ts` (52 tests), renamed-column proof tests in `test/unit/SqlGeneration.test.ts` |
 | Identifier & operator validation (injection payloads rejected end-to-end) | `test/unit/Injection.test.ts` (90 tests) |
 | Query filters on every read path incl. `groupBy()`, having-placeholder ordering, legacy-lambda limitations | `test/unit/QueryFilterCoverage.test.ts` |
-| Row→entity mapping characterization (both paths, converters, shadow columns, tracking) | `test/unit/EntityMapper.test.ts` |
+| row to entity mapping characterization (both paths, converters, shadow columns, tracking) | `test/unit/EntityMapper.test.ts` |
 | Identity map (same instance on re-query, eager-loaded relations, `attach()`/`update()`, converted keys, eviction, no-tracking exclusion) | `test/unit/IdentityMap.test.ts` |
 
 If a claim in this README is not represented in this map or the linked suites, treat it as unverified and [open an issue](https://github.com/BaryoDev/rnxORM/issues).
 
 ### Testing status
 
-The test suite (534 tests, all passing) runs against an **in-memory mock provider** by default — it validates the ORM's tracking, metadata, eager loading, and per-dialect SQL-generation logic without infrastructure. The same suite also runs against **real PostgreSQL 16, MariaDB 11, and SQL Server 2022** containers on every pull request and push to `main` (`.github/workflows/integration.yml`), and locally via `docker compose -f docker-compose.test.yml up -d --wait && npm run test:integration`.
+The test suite (534 tests, all passing) runs against an **in-memory mock provider** by default. It validates the ORM's tracking, metadata, eager loading, and per-dialect SQL-generation logic without infrastructure. The same suite also runs against **real PostgreSQL 16, MariaDB 11, and SQL Server 2022** containers on every pull request and push to `main` (`.github/workflows/integration.yml`), and locally via `docker compose -f docker-compose.test.yml up -d --wait && npm run test:integration`.
 
 ## Type Mapping
 
@@ -285,9 +309,9 @@ price!: number;
 
 `BETWEEN` is **not** supported; express it as two conditions: `.where('age', '>=', 18).where('age', '<=', 65)`.
 
-`where()`, `orderBy()`, and `orderByDescending()` on `DbSet`, `QueryBuilder`, and `SelectQueryBuilder` carry `keyof T` overloads, so property-name literals autocomplete and typo-check in editors. (Grouped `orderBy()` stays string-only: it also accepts projection aliases, which are not properties of `T`.) The plain-string forms remain supported for dynamic columns — now safe to use with untrusted input like `orderBy(req.query.sort)`, which throws instead of reaching SQL (see [SECURITY.md](SECURITY.md)).
+`where()`, `orderBy()`, and `orderByDescending()` on `DbSet`, `QueryBuilder`, and `SelectQueryBuilder` carry `keyof T` overloads, so property-name literals autocomplete and typo-check in editors. (Grouped `orderBy()` stays string-only: it also accepts projection aliases, which are not properties of `T`.) The plain-string forms remain supported for dynamic columns. Now safe to use with untrusted input like `orderBy(req.query.sort)`, which throws instead of reaching SQL (see [SECURITY.md](SECURITY.md)).
 
-`skip()` and `take()` require a non-negative integer. They are the only query arguments interpolated into SQL rather than bound, so they are checked at runtime — TypeScript's `number` type does not survive to runtime.
+`skip()` and `take()` require a non-negative integer. They are the only query arguments interpolated into SQL rather than bound, so they are checked at runtime. TypeScript's `number` type does not survive to runtime.
 
 ```typescript
 // Examples
@@ -466,7 +490,7 @@ await db.saveChanges(); // Nothing happens
 
 rnxORM supports all major relationship types with automatic foreign key generation and eager loading.
 
-> **How eager loading works**: `.include()` issues batched follow-up queries (`SELECT ... WHERE fk IN (...)`) and stitches the related entities together in memory — it does not generate SQL JOINs. Only one level of include is supported (no nested `thenInclude`).
+> **How eager loading works**: `.include()` issues batched follow-up queries (`SELECT ... WHERE fk IN (...)`) and stitches the related entities together in memory. It does not generate SQL JOINs. Only one level of include is supported (no nested `thenInclude`).
 
 ### One-to-Many / Many-to-One
 
@@ -509,8 +533,7 @@ users[0].posts.forEach(post => console.log(post.title));
 
 > **Declaration order matters**: `@ManyToMany` derives its default join-table
 > name from the related class at decoration time, and TypeScript's
-> `emitDecoratorMetadata` embeds a direct reference to the property's type —
-> so declare a class **before** any class whose decorated properties
+> `emitDecoratorMetadata` embeds a direct reference to the property's type. > so declare a class **before** any class whose decorated properties
 > reference it, or you'll hit `ReferenceError: Cannot access 'X' before
 > initialization` at import time. See `examples/02-relationships.ts` for a
 > working ordering.
@@ -856,7 +879,7 @@ await db.ensureCreated(); // Seeds data automatically
 
 ## Default Values & Computed Columns *(Planned)*
 
-> **Note**: These APIs currently only **store configuration metadata — they have no runtime effect yet**. `hasDefaultValue()` is not emitted as a `DEFAULT` clause in `CREATE TABLE` and is not used during inserts; `hasComputedColumnSql()` does not generate `GENERATED ALWAYS AS` columns. Full support is planned. If you need defaults or computed columns today, define them in a migration with raw SQL (`builder.sql(...)`) or via `MigrationBuilder.createTable`, which does support `defaultValue`.
+> **Note**: These APIs currently only **store configuration metadata. They have no runtime effect yet**. `hasDefaultValue()` is not emitted as a `DEFAULT` clause in `CREATE TABLE` and is not used during inserts; `hasComputedColumnSql()` does not generate `GENERATED ALWAYS AS` columns. Full support is planned. If you need defaults or computed columns today, define them in a migration with raw SQL (`builder.sql(...)`) or via `MigrationBuilder.createTable`, which does support `defaultValue`.
 
 ### Default Values
 
@@ -938,16 +961,16 @@ Global query filters automatically apply to all queries for an entity, making th
 ### Defining Query Filters
 
 Use `hasQueryFilter()` in your `onModelCreating()` method. The **structured
-form** is preferred — its conditions are translated to parameterized SQL
+form** is preferred. Its conditions are translated to parameterized SQL
 `WHERE` clauses, so filtered rows never leave the database:
 
 ```typescript
 protected onModelCreating(modelBuilder: ModelBuilder): void {
-    // Soft delete filter — becomes "WHERE isDeleted = $1" in SQL
+    // Soft delete filter. Becomes "WHERE isDeleted = $1" in SQL
     modelBuilder.entity(User)
         .hasQueryFilter({ property: 'isDeleted', operator: '=', value: false });
 
-    // Multi-tenant filter — pass a function to resolve the value at query time
+    // Multi-tenant filter. Pass a function to resolve the value at query time
     modelBuilder.entity(Document)
         .hasQueryFilter({ property: 'tenantId', operator: '=', value: () => this.currentTenantId });
 
@@ -961,7 +984,7 @@ protected onModelCreating(modelBuilder: ModelBuilder): void {
 ```
 
 `property` is the entity property name (mapped to its column, with value
-converters applied — per element for `IN`/`NOT IN`), and `operator` must come
+converters applied. Per element for `IN`/`NOT IN`), and `operator` must come
 from the same validated set as `where()`: `=`, `!=`, `<>`, `>`, `<`, `>=`,
 `<=`, `LIKE`, `ILIKE`, `NOT LIKE`, `IN`, `NOT IN`, `IS`, `IS NOT`. The operator
 is checked when `hasQueryFilter()` runs, so a typo fails at startup rather than
@@ -974,7 +997,7 @@ modelBuilder.entity(User).hasQueryFilter({ property: 'deletedAt', operator: 'IS'
 ```
 
 The **predicate form** is still supported for arbitrary JavaScript logic, but
-runs **in memory after rows are fetched** — the SQL is not modified, so
+runs **in memory after rows are fetched**. The SQL is not modified, so
 filtered-out rows still cross the wire:
 
 ```typescript
@@ -1003,7 +1026,7 @@ const activeCount = await db.set(User).count();
 > **Scope**: structured filters apply to `toList()`, `find()`, `where()`
 > chains, aggregates (`count`/`sum`/`average`/`min`/`max`), `select()`
 > projections, and `groupBy()` queries (injected into the WHERE clause ahead
-> of GROUP BY/HAVING). Raw SQL is the one path that is not rewritten — raw
+> of GROUP BY/HAVING). Raw SQL is the one path that is not rewritten. Raw
 > SQL results are filtered in memory instead. Filters are a convenience, not
 > a tenant-isolation boundary; see [SECURITY.md](SECURITY.md).
 >
@@ -1264,7 +1287,7 @@ export class User {
 
 **Current Behavior:**
 - Shadow properties are **included in CREATE TABLE** statements as plain columns
-- Their `defaultValue` is sent as a **literal parameter value in INSERT statements** — it is *not* emitted as a DDL `DEFAULT` clause
+- Their `defaultValue` is sent as a **literal parameter value in INSERT statements**. It is *not* emitted as a DDL `DEFAULT` clause
 - They're **excluded from entity mapping** (not set on TypeScript objects)
 
 > **Limitation**: Because defaults are bound as parameter values, SQL expressions like `'CURRENT_TIMESTAMP'` or `'NOW()'` are inserted as literal strings and will fail or store the wrong value on real databases. Use **constant defaults only** (numbers, strings, booleans) with shadow properties for now. DDL `DEFAULT` clause support is planned.
@@ -1393,7 +1416,7 @@ When you need to execute complex SQL that can't be expressed through the fluent 
 
 Execute raw SQL and map results to entity types.
 
-> **Placeholder syntax is provider-specific** — rnxORM does not translate placeholders in raw SQL. Use `$1, $2, ...` for PostgreSQL (as in the examples below), `@p0, @p1, ...` for SQL Server, and `?` for MariaDB/MySQL.
+> **Placeholder syntax is provider-specific**. RnxORM does not translate placeholders in raw SQL. Use `$1, $2, ...` for PostgreSQL (as in the examples below), `@p0, @p1, ...` for SQL Server, and `?` for MariaDB/MySQL.
 
 ```typescript
 // Simple raw query
@@ -1616,7 +1639,7 @@ const stats = await db.set(OrderStatistics)
 
 ## Owned Entity Types *(Planned)*
 
-> **Note**: `ownsOne()` and `ownsMany()` currently only **store configuration metadata — they have no runtime effect yet**. No flattened columns are added to the owner's table, no separate table is created for owned collections, and owned objects are not persisted or hydrated. The documentation below describes the planned design. Until it ships, model value objects as regular columns (e.g. with a JSON value converter via `hasConversion()`).
+> **Note**: `ownsOne()` and `ownsMany()` currently only **store configuration metadata. They have no runtime effect yet**. No flattened columns are added to the owner's table, no separate table is created for owned collections, and owned objects are not persisted or hydrated. The documentation below describes the planned design. Until it ships, model value objects as regular columns (e.g. with a JSON value converter via `hasConversion()`).
 
 Owned entity types are entities that don't have their own identity and are always accessed through their owner entity. They're perfect for value objects like addresses, money, or other complex types that belong to a parent entity.
 
@@ -1941,7 +1964,7 @@ async function updateWithRetry(product: Product, changes: Partial<Product>) {
 
 For read-only queries, use `asNoTracking()` to improve performance. Entities returned from no-tracking queries are not registered in the change tracker, so modifying them has no effect on `saveChanges()`.
 
-> **Note**: No-tracking entities are ordinary mutable objects — they are *not* frozen. Modifications simply won't be persisted.
+> **Note**: No-tracking entities are ordinary mutable objects. They are *not* frozen. Modifications simply won't be persisted.
 
 ```typescript
 // Read-only query - entities are not tracked
@@ -2141,8 +2164,8 @@ builder.sql('UPDATE users SET status = $1 WHERE created_at < $2', ['inactive', n
 ### Running Migrations from the CLI
 
 `migration:run`, `migration:revert`, and `migration:status` load a config
-module — `rnxorm.config.js` in the working directory by default, or any path
-passed via `--config` — that exports a `createMigrator()` factory:
+module. `rnxorm.config.js` in the working directory by default, or any path
+passed via `--config`. That exports a `createMigrator()` factory:
 
 ```javascript
 // rnxorm.config.js

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 ## Reporting a vulnerability
 
 Use GitHub's private vulnerability reporting on this repository
-(Security tab → "Report a vulnerability"). If that is unavailable, open an
+(Security tab to "Report a vulnerability"). If that is unavailable, open an
 issue that says only "security report, requesting contact" without details,
 and a maintainer will follow up privately.
 
@@ -29,13 +29,13 @@ Honest scope, so you can threat-model correctly:
   `orderBy()`, and `having()` reject identifiers that are not mapped columns of
   the entity and operators outside the supported set, so untrusted input like
   `orderBy(req.query.sort)` fails loudly instead of reaching SQL. On 2.1.x and
-  earlier these were interpolated unvalidated — do not pass untrusted input to
+  earlier these were interpolated unvalidated. Do not pass untrusted input to
   them on old versions.
   One documented exception: `orderBy()` on a **grouped** query also accepts a
   projection alias, which exists only in the SELECT list and cannot be checked
   against entity metadata. Such aliases are required to be plain identifiers
-  (`^[A-Za-z_][A-Za-z0-9_]*$`), so injection-shaped strings — anything with
-  quotes, whitespace, semicolons, or comment markers — are still rejected.
+  (`^[A-Za-z_][A-Za-z0-9_]*$`), so injection-shaped strings. Anything with
+  quotes, whitespace, semicolons, or comment markers. Are still rejected.
 - **Row limits are validated at runtime** (2.2.0+): `skip()` and `take()` must
   receive a non-negative integer. They are the only query-API arguments that
   are interpolated rather than bound (no driver accepts a parameter for

--- a/TEST_SUMMARY.md
+++ b/TEST_SUMMARY.md
@@ -1,6 +1,6 @@
 # rnxORM Test Suite Summary
 
-## Current state: 534 tests passing — mock by default, real databases via docker and CI
+## Current state: 534 tests passing. Mock by default, real databases via docker and CI
 
 The default `npm test` run uses the in-memory `MockDatabaseProvider` (fast, no
 infrastructure). The same suite runs against **real PostgreSQL, MariaDB,
@@ -40,9 +40,9 @@ docker compose -f docker-compose.test.yml down -v
 | PropertyCapture | 52 | Recording-Proxy selector capture: property/projection/aggregate classification, nested, computed and short-circuit (`||`/`??`/ternary) selectors as `opaque`, `g.key`, `average` alias |
 | Injection | 90 | Identifier/operator validation: closed operator set (incl. `IN`/`NOT IN`/`IS`/`IS NOT` expansion), metadata-checked columns, having-expression shapes, non-integer `skip()`/`take()` payloads, end-to-end rejection of injection payloads through `where()`/`orderBy()`/`having()`/`skip()`/`take()` |
 | QueryFilterCoverage | 23 | Structured filters proven on every read path (count, pagination per dialect, all(), aggregates, select, find, groupBy incl. having placeholder ordering); legacy-lambda limitations pinned |
-| EntityMapper | 15 | Row→entity characterization for both mapping paths: renamed columns, converters, shadow-column exclusion, tracked vs asNoTracking |
+| EntityMapper | 15 | row to entity characterization for both mapping paths: renamed columns, converters, shadow-column exclusion, tracked vs asNoTracking |
 | IdentityMap | 18 | Same tracked instance on repeated loads (find/toList) and through `include()`, entities entering tracking via attach/update/add, value-converted keys, local modifications survive re-query, eviction on delete/clear, asNoTracking excluded, per-context isolation |
-| ActualApi (integration) | 18 | CRUD, all documented comparison operators (incl. LIKE, IN/NOT IN, IS/IS NOT with real placeholder expansion), pagination and its runtime validation, ordering, bulk ops, SQL-injection safety, unicode — per provider when run with USE_REAL_DB |
+| ActualApi (integration) | 18 | CRUD, all documented comparison operators (incl. LIKE, IN/NOT IN, IS/IS NOT with real placeholder expansion), pagination and its runtime validation, ordering, bulk ops, SQL-injection safety, unicode. Per provider when run with USE_REAL_DB |
 
 ## What the real-database run has verified
 
@@ -62,7 +62,7 @@ docker compose -f docker-compose.test.yml down -v
 
 - **Solid**: change tracking, transactions, concurrency tokens, migrations
   (library API and CLI), query/pagination SQL generation, SQL-translated query
-  filters, eager loading, value converters, keyless entities, seeding —
+  filters, eager loading, value converters, keyless entities, seeding , 
   tested at the SQL level and against real engines.
 - **Not implemented** (see README feature status): owned entities, DDL default
   values, computed columns, explicit loading, lazy loading.

--- a/docs/audits/2026-08-25-issue-audit.md
+++ b/docs/audits/2026-08-25-issue-audit.md
@@ -1,4 +1,4 @@
-# Open-issue audit — 2026-08-25
+# Open-issue audit. 2026-08-25
 
 Every open issue, audited against the code on `main` (55ebb67) and dispositioned.
 "This PR" = the `fix/issue-audit-hardening` branch this document ships on.
@@ -7,16 +7,16 @@ Every open issue, audited against the code on `main` (55ebb67) and dispositioned
 
 | Issue | What was missing | What landed |
 |-------|------------------|-------------|
-| #3 / #21 | `extractPropertyName` regex-parsed `Function.prototype.toString()`; `u => u.address.city` silently returned `address`, comments could change the resolved column | `src/core/expressions/PropertyCapture.ts` — recording-Proxy capture (ported from the reviewed phase-1 branch). Nested access, computed values, and coercions now classify as `opaque` and fail loudly or fall back explicitly. `extractPropertyName` and `src/core/utils.ts` are deleted. |
-| #16 | include/sum/average/min/max still on the regex | All routed through `resolvePropertyName`/`resolveColumn` (28 call sites across DbSet, ModelBuilder, decorators — `grep extractPropertyName src/` returns nothing) |
+| #3 / #21 | `extractPropertyName` regex-parsed `Function.prototype.toString()`; `u => u.address.city` silently returned `address`, comments could change the resolved column | `src/core/expressions/PropertyCapture.ts`. Recording-Proxy capture (ported from the reviewed phase-1 branch). Nested access, computed values, and coercions now classify as `opaque` and fail loudly or fall back explicitly. `extractPropertyName` and `src/core/utils.ts` are deleted. |
+| #16 | include/sum/average/min/max still on the regex | All routed through `resolvePropertyName`/`resolveColumn` (28 call sites across DbSet, ModelBuilder, decorators. `grep extractPropertyName src/` returns nothing) |
 | #17 | select()/groupBy() projections on two more regexes | Rebuilt on `capture()`/`captureAggregates()`: unmapped projected property throws, opaque selectors fall back to in-memory projection, `g.key` aliases the group column, `g.average` works; renamed-column tests prove the mapped column (not the property name) reaches SQL |
-| #13 / #24 | `where()`/`orderBy()`/`having()` interpolated column and operator unvalidated — injectable via the sortable-table pattern; shipped in 2.1.0 | `src/core/Identifiers.ts`: columns validated against entity metadata (property or column spelling, renamed columns resolved), operators against a closed set, `having()` restricted to aggregate-over-mapped-column shapes, grouped `orderBy()` to mapped columns or plain-identifier aliases. End-to-end tests prove payloads throw before SQL assembly. Plus `SECURITY.md` (also requested by #13). |
-| #22 (remainder) | `compileQueryFilter` interpolated the filter **operator** unvalidated — the same injection class in a second location (flagged in the issue's own comment) | Filter operators now pass through the same closed set |
+| #13 / #24 | `where()`/`orderBy()`/`having()` interpolated column and operator unvalidated. Injectable via the sortable-table pattern; shipped in 2.1.0 | `src/core/Identifiers.ts`: columns validated against entity metadata (property or column spelling, renamed columns resolved), operators against a closed set, `having()` restricted to aggregate-over-mapped-column shapes, grouped `orderBy()` to mapped columns or plain-identifier aliases. End-to-end tests prove payloads throw before SQL assembly. Plus `SECURITY.md` (also requested by #13). |
+| #22 (remainder) | `compileQueryFilter` interpolated the filter **operator** unvalidated. The same injection class in a second location (flagged in the issue's own comment) | Filter operators now pass through the same closed set |
 | #23 (remainder) | `groupBy()` was the last read path ignoring structured query filters; `having()` placeholder baking made a naive fix corrupt parameter order | Both `groupBy()` factories inject the compiled filter eagerly (before `having()` can bake indices); `ignoreQueryFilters()` respected; proof tests include the having+filter ordering case. Coverage tests now prove filters on every read path: `count`, `skip/take` per dialect, `all()`, aggregates, `select()`, `find()`, `groupBy()`. |
 | #19 | `all()` unverified against filters; limitations undocumented | `all()` filter coverage proven by test; the legacy-lambda limitation (in-memory only, `count()` counts unfiltered rows) is pinned by test and documented in the README |
-| #15 | No characterization tests for row→entity mapping (the safety net for the future #20 split) | `test/unit/EntityMapper.test.ts` pins both mapping paths: renamed columns, converters, shadow-property exclusion, tracked vs no-tracking registration |
-| #5 | ChangeTracker keyed by object identity; `find(1)` twice produced two tracked instances → conflicting UPDATEs | Identity map (type + primary key) in ChangeTracker; re-materialization returns the existing tracked instance, local modifications survive re-query, deletion/clear evict |
-| #26 (partial) | No compile-time help on `where`/`orderBy` | Additive `keyof T` overloads for editor autocomplete. Full compile-time *enforcement* requires removing the string overloads — a breaking change deferred to 3.0 (see "Not in this PR"). |
+| #15 | No characterization tests for row to entity mapping (the safety net for the future #20 split) | `test/unit/EntityMapper.test.ts` pins both mapping paths: renamed columns, converters, shadow-property exclusion, tracked vs no-tracking registration |
+| #5 | ChangeTracker keyed by object identity; `find(1)` twice produced two tracked instances to conflicting UPDATEs | Identity map (type + primary key) in ChangeTracker; re-materialization returns the existing tracked instance, local modifications survive re-query, deletion/clear evict |
+| #26 (partial) | No compile-time help on `where`/`orderBy` | Additive `keyof T` overloads for editor autocomplete. Full compile-time *enforcement* requires removing the string overloads. A breaking change deferred to 3.0 (see "Not in this PR"). |
 | #11 (remainder) | No issue/PR templates (CONTRIBUTING itself landed in #27) | `.github/ISSUE_TEMPLATE/` (bug, feature, security contact link) + `PULL_REQUEST_TEMPLATE.md` with the evidence checklist |
 | #6 (remainder) | No publish gate: 6 npm versions shipped without a real-DB run | `.github/workflows/release.yml`: publish requires the full suite green against real PostgreSQL, MariaDB, and SQL Server; dry-run is the default mode so the gate can be exercised before it matters. (Real-DB integration on every PR/push already landed on `main`.) |
 
@@ -33,7 +33,7 @@ tmpdir symlink).
 | #4 | The query model is the architecture follow-up to #20; the issues themselves order it after the split. |
 | #7 / #10 | Both explicitly depend on #4 (SQLite as proof of the dialect boundary; packages need a real provider boundary first). |
 | #8 / #12 | Decision records (MySQL deferred, MariaDB maintenance-only), not code. PR #14 carries the positioning docs. |
-| #26 (full) | Compile-time enforcement means dropping the string overloads — breaking, 3.0 material. The runtime validation in this PR closes the security half now. |
+| #26 (full) | Compile-time enforcement means dropping the string overloads. Breaking, 3.0 material. The runtime validation in this PR closes the security half now. |
 | #25 | The release itself. This PR is its prerequisite; the release gate it requires now exists (`release.yml`). Run integration, merge, then release 2.2.0 through the gate. |
 
 ## Suggested issue actions after merge

--- a/examples/02-relationships.ts
+++ b/examples/02-relationships.ts
@@ -17,7 +17,7 @@ import { PostgreSQLProvider } from "../src/providers";
 // its related-entity function eagerly (to derive the default join table
 // name). Both effectively require the referenced class to already exist, so
 // Genre and Author are declared before Book. Only one side of a ManyToMany
-// needs the decorator — the join table itself is symmetric.
+// needs the decorator. The join table itself is symmetric.
 @Entity("ex2_genres")
 class Genre {
     @PrimaryKey()
@@ -121,7 +121,7 @@ async function main() {
     genres.addRange([fantasy, classics]);
     await db.saveChanges();
 
-    // There is no fluent "add to collection" API for many-to-many yet — the
+    // There is no fluent "add to collection" API for many-to-many yet. The
     // join table is a plain table, so it's populated directly.
     await db.executeSqlRaw(
         "INSERT INTO ex2_book_genres (bookid, genreid) VALUES ($1, $2), ($1, $3)",

--- a/examples/03-query-filters-and-security.ts
+++ b/examples/03-query-filters-and-security.ts
@@ -2,7 +2,7 @@
  * rnxORM Query Filters & Security
  *
  * Part 1: a structured hasQueryFilter() soft-delete filter, and how count(),
- * pagination, and groupBy() all respect it automatically — plus
+ * pagination, and groupBy() all respect it automatically. Plus
  * ignoreQueryFilters() to bypass it deliberately.
  *
  * Part 2: the security showcase. orderBy() (like where() and having())

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,7 @@ manual cleanup, and running one example never touches another's tables.
 
 These examples import from `../src` (the package source) so they run
 directly against this checkout. In your own app, install `rnxorm` and import
-from the package name instead, e.g. `import { DbContext } from "rnxorm";` —
-each file's header comment shows the equivalent import.
+from the package name instead, e.g. `import { DbContext } from "rnxorm";`. Each file's header comment shows the equivalent import.
 
 ## Running
 

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ Implemented:
 - **Relationships**: `@ManyToOne`, `@OneToMany`, `@ManyToMany`, `@OneToOne`
 - **Change Tracking & SaveChanges()**: EF Core-style automatic change detection, single transaction
 - **Fluent API / ModelBuilder**: Configure entities programmatically via `onModelCreating()`
-- **Eager Loading**: `.include()` — batched follow-up queries (WHERE pk IN (...)), NOT JOINs; single-level only
+- **Eager Loading**: `.include()`. Batched follow-up queries (WHERE pk IN (...)), NOT JOINs; single-level only
 - **Data Seeding**: `hasData()`, idempotent by primary key
 - **Migrations (library API)**: `MigrationBuilder` and `Migrator` with per-dialect SQL and history tracking
 - **Aggregations**: `sum`, `average`, `min`, `max`, `count` as real SQL aggregates
@@ -19,24 +19,24 @@ Implemented:
 - **Bulk Operations**: `addRange`, `updateRange`, `removeRange` (per-row statements, one transaction)
 - **Schema Evolution**: `ensureCreated()` adds missing columns, best-effort type migration
 - **Query Optimization**: `.asNoTracking()` skips change tracking (entities are NOT frozen)
-- **Global Query Filters (structured form)**: `hasQueryFilter({ property, operator, value })` — translated to SQL WHERE clauses on toList/find/where-chains/aggregates/select; `value` may be a function resolved at query time; bypass with `ignoreQueryFilters()`
+- **Global Query Filters (structured form)**: `hasQueryFilter({ property, operator, value })`. Translated to SQL WHERE clauses on toList/find/where-chains/aggregates/select; `value` may be a function resolved at query time; bypass with `ignoreQueryFilters()`
 - **Migration CLI**: `migration:create` scaffolds; `migration:run`/`revert`/`status` load a `rnxorm.config.js` (or `--config <path>`) exporting `createMigrator()`
 
 Partial (works with limitations):
 - **LINQ-Style Projections**: `select`/`groupBy` lambdas are resolved by a recording Proxy (no regex, no toString parsing); simple property/object-literal shapes and `g.key`/aggregates translate to SQL with mapped column names; an unmapped projected property throws; computed selectors (template strings, arithmetic, `||`/`??`/ternary between columns) fall back to in-memory projection where a fallback exists, otherwise throw
-- **Global Query Filters (predicate form)**: `hasQueryFilter(u => ...)` predicates run in memory after fetching — never translated to SQL; prefer the structured form, which IS translated on every read path including groupBy(). Raw SQL results are filtered in memory by both forms
-- **Raw SQL**: `fromSqlRaw()`/`executeSqlRaw()` — placeholders are provider-native ($1 postgres, @p0 mssql, ? mariadb), not translated
+- **Global Query Filters (predicate form)**: `hasQueryFilter(u => ...)` predicates run in memory after fetching. Never translated to SQL; prefer the structured form, which IS translated on every read path including groupBy(). Raw SQL results are filtered in memory by both forms
+- **Raw SQL**: `fromSqlRaw()`/`executeSqlRaw()`. Placeholders are provider-native ($1 postgres, @p0 mssql, ? mariadb), not translated
 - **Keyless Entity Types**: `hasNoKey()` queries views; read-only not enforced
-- **Shadow Properties**: columns created, but defaults are bound as literal parameter values — SQL expressions like CURRENT_TIMESTAMP do not work
+- **Shadow Properties**: columns created, but defaults are bound as literal parameter values. SQL expressions like CURRENT_TIMESTAMP do not work
 
-NOT implemented (API accepts config but has no runtime effect — do not rely on):
+NOT implemented (API accepts config but has no runtime effect. Do not rely on):
 - **Owned Entity Types** (`ownsOne()`/`ownsMany()`)
 - **Default Values** (`hasDefaultValue()` on regular columns)
 - **Computed Columns** (`hasComputedColumnSql()`)
 - **Explicit Loading** (`entry().reference()`/`collection()` throw)
 - **Lazy Loading**
 
-Testing: the suite (534 tests) runs against an in-memory mock provider by default and against real PostgreSQL/MariaDB/SQL Server containers in CI on every PR and push to main. The README Features section carries a feature→test verification map; treat claims outside it as unverified.
+Testing: the suite (534 tests) runs against an in-memory mock provider by default and against real PostgreSQL/MariaDB/SQL Server containers in CI on every PR and push to main. The README Features section carries a feature-to-test verification map; treat claims outside it as unverified.
 
 ## Installation
 
@@ -141,9 +141,9 @@ Each provider implements `IDatabaseProvider` with a `getDialect()` method return
 - `first()` / `firstOrThrow()`: Get first result
 - `single()` / `singleOrDefault()`: Get exactly one result
 - `count()`: Count matching entities
-- `where(col, op, val)`: Filter entities. `op` comes from a closed, runtime-validated set: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`, `LIKE`, `ILIKE`, `NOT LIKE`, `IN`, `NOT IN`, `IS`, `IS NOT`. `IN`/`NOT IN` take an array (empty array => `1 = 0` / `1 = 1`); `IS`/`IS NOT` take `null`. `BETWEEN` is unsupported — use two `where()` calls
+- `where(col, op, val)`: Filter entities. `op` comes from a closed, runtime-validated set: `=`, `!=`, `<>`, `>`, `<`, `>=`, `<=`, `LIKE`, `ILIKE`, `NOT LIKE`, `IN`, `NOT IN`, `IS`, `IS NOT`. `IN`/`NOT IN` take an array (empty array => `1 = 0` / `1 = 1`); `IS`/`IS NOT` take `null`. `BETWEEN` is unsupported. Use two `where()` calls
 - `orderBy(col)` / `orderByDescending(col)`: Sort results. Column names are validated against entity metadata
-- `skip(n)` / `take(n)`: Pagination. `n` must be a non-negative integer (validated at runtime — these are interpolated, not bound)
+- `skip(n)` / `take(n)`: Pagination. `n` must be a non-negative integer (validated at runtime. These are interpolated, not bound)
 - `include(selector)`: Eager load related entities (tracked and identity-mapped unless `asNoTracking()`)
 - `select(selector)`: Project to a different shape
 - `groupBy(selector)`: Group results
@@ -159,16 +159,16 @@ Each provider implements `IDatabaseProvider` with a `getDialect()` method return
 - `.hasIndex(selector)` / `.hasCompositeIndex(selectors)`: Add indexes
 - `.hasUnique(selector)`: Add unique constraint
 - `.hasData(seedArray)`: Seed initial data
-- `.hasQueryFilter(conditions | predicate)`: Add global query filter — structured conditions ({ property, operator, value }) are translated to SQL; predicates run in memory
+- `.hasQueryFilter(conditions | predicate)`: Add global query filter. Structured conditions ({ property, operator, value }) are translated to SQL; predicates run in memory
 - `.hasNoKey()`: Mark as keyless entity
-- `.ownsOne(selector, Type)` / `.ownsMany(selector, Type)`: Configure owned entities (planned — no runtime effect yet)
+- `.ownsOne(selector, Type)` / `.ownsMany(selector, Type)`: Configure owned entities (planned. No runtime effect yet)
 - `.shadowProperty(name, type, options)`: Add database-only column
 - `.property(selector)`: Configure a property
   - `.isRequired()` / `.isOptional()`: Nullability
   - `.hasMaxLength(n)`: Max string length
   - `.hasColumnName(name)` / `.hasColumnType(type)`: Column mapping
-  - `.hasDefaultValue(val)`: Default value (planned — no runtime effect yet)
-  - `.hasComputedColumnSql(sql)`: Computed column (planned — no runtime effect yet)
+  - `.hasDefaultValue(val)`: Default value (planned. No runtime effect yet)
+  - `.hasComputedColumnSql(sql)`: Computed column (planned. No runtime effect yet)
   - `.hasConversion(toDB, fromDB)`: Value converter
   - `.isConcurrencyToken()`: Optimistic concurrency
 

--- a/src/core/ChangeTracker.ts
+++ b/src/core/ChangeTracker.ts
@@ -45,7 +45,7 @@ export class ChangeTracker {
 
     /**
      * Identity-map an entity that entered tracking without a database round
-     * trip — `attach()`, `update()`, or `add()` with an explicit key. Without
+     * trip. `attach()`, `update()`, or `add()` with an explicit key. Without
      * this, a later `find()` for the same key maps a second instance and the
      * context holds two tracked copies of one row (issue #5's third door).
      *

--- a/src/core/DbContext.ts
+++ b/src/core/DbContext.ts
@@ -211,7 +211,7 @@ export class DbContext {
 
         // A generated key comes back in the database's own representation, so
         // it goes through the column's convertFromDb before landing on the
-        // entity — the same conversion the row-mapping path applies. Otherwise
+        // entity. The same conversion the row-mapping path applies. Otherwise
         // a converted key would sit on the entity in its raw form and the
         // identity map would key insert-then-find differently.
         const fromDb = (value: any) =>
@@ -525,7 +525,7 @@ export class DbContext {
                             const alterColumnSql = this.provider.generateAlterColumnTypeSql(entity.tableName, col);
                             await this.query(alterColumnSql);
                         } catch {
-                            // Type migration failed — data may be incompatible
+                            // Type migration failed. Data may be incompatible
                         }
                     }
                 }

--- a/src/core/DbSet.ts
+++ b/src/core/DbSet.ts
@@ -480,7 +480,7 @@ export class QueryBuilder<T> {
         // operator set before touching SQL (issues #13/#24); the value is
         // always bound as a parameter. buildComparison owns placeholder
         // expansion, so IN binds one placeholder per element and IS binds none
-        // — the next condition numbers from the updated params length.
+        //. The next condition numbers from the updated params length.
         const sqlColumn = assertColumn(this.entityType, column, 'where');
         const comparison = buildComparison(
             sqlColumn, operator, value, this.context.getProvider(), this.params.length + 1, 'where'
@@ -1349,7 +1349,7 @@ export class GroupedQueryBuilder<T, TKey> {
      * @internal Called by the groupBy() factories, and deliberately BEFORE the
      * caller can invoke having(): having() bakes placeholder indices from the
      * current params length at call time, so filters appended any later would
-     * silently shift every HAVING placeholder (issue #23 — groupBy was the
+     * silently shift every HAVING placeholder (issue #23. GroupBy was the
      * last read path that ignored structured query filters). Function-valued
      * filter conditions are therefore resolved when groupBy() is called.
      */

--- a/src/core/Identifiers.ts
+++ b/src/core/Identifiers.ts
@@ -44,9 +44,9 @@ export function assertOperator(operator: string, apiName: string): string {
 /**
  * Validate a row-limit argument (`skip()` / `take()`).
  *
- * These are the only query-API arguments that must be interpolated into SQL —
+ * These are the only query-API arguments that must be interpolated into SQL , 
  * `LIMIT`/`OFFSET`/`OFFSET ... FETCH NEXT` do not accept a bound parameter on
- * every supported driver — so they need a runtime guard of their own. The
+ * every supported driver. So they need a runtime guard of their own. The
  * check exists *because* TypeScript's `number` erases at runtime: an `as any`
  * cast, an untyped `req.query.limit`, or a JSON body puts a string here and it
  * used to land verbatim in the statement.
@@ -71,7 +71,7 @@ export function assertLimit(value: number, apiName: string): number {
  *
  * @param columnSql Already-validated column name (see assertColumn)
  * @param operator Raw operator string; validated against the closed set here
- * @param value Value to bind — an array for IN/NOT IN, null for IS/IS NOT
+ * @param value Value to bind. An array for IN/NOT IN, null for IS/IS NOT
  * @param provider Database provider used for placeholder syntax
  * @param nextParamIndex 1-based placeholder index this condition starts at
  * @param apiName Public API name used in error messages
@@ -136,7 +136,7 @@ export function assertColumn(
     const metadata = MetadataStorage.get().getEntity(entityType);
     if (!metadata) {
         throw new Error(
-            `${apiName}(): cannot validate column '${name}' — ${entityType.name} has no entity metadata`
+            `${apiName}(): cannot validate column '${name}'. ${entityType.name} has no entity metadata`
         );
     }
 
@@ -177,7 +177,7 @@ export function assertHavingExpression(
  * Validate an ORDER BY target on grouped queries, where the target may be a
  * mapped column or a projection alias that only exists in the SELECT list.
  * Aliases cannot be checked against metadata, so they must at least be shaped
- * like a plain identifier — which rules out every injection vector (quotes,
+ * like a plain identifier. Which rules out every injection vector (quotes,
  * whitespace, semicolons, comment markers).
  * @throws when the name is neither a mapped column/property nor a plain identifier
  */

--- a/src/core/MetadataStorage.ts
+++ b/src/core/MetadataStorage.ts
@@ -82,7 +82,7 @@ export interface OwnedEntityMetadata {
 /**
  * A structured global query filter condition that can be translated to SQL.
  * `property` is the entity property name (mapped to its column), `operator`
- * is a SQL comparison operator, and `value` is the comparison value — pass a
+ * is a SQL comparison operator, and `value` is the comparison value. Pass a
  * function to resolve the value at query time (e.g. a current tenant id).
  */
 export interface QueryFilterCondition {

--- a/src/core/ModelBuilder.ts
+++ b/src/core/ModelBuilder.ts
@@ -516,7 +516,7 @@ export class EntityTypeBuilder<T> {
      * The filter is automatically applied to all queries; bypass it per-query
      * with ignoreQueryFilters().
      *
-     * Preferred form — structured conditions, translated to SQL WHERE clauses
+     * Preferred form. Structured conditions, translated to SQL WHERE clauses
      * so filtered rows never leave the database. Pass a function as `value`
      * to resolve it at query time (e.g. the current tenant id):
      * @example
@@ -528,7 +528,7 @@ export class EntityTypeBuilder<T> {
      * modelBuilder.entity(Order)
      *     .hasQueryFilter({ property: 'tenantId', operator: '=', value: () => currentTenantId });
      *
-     * Legacy form — a predicate function, evaluated in memory after rows are
+     * Legacy form. A predicate function, evaluated in memory after rows are
      * fetched. Correct, but filtered-out rows still cross the wire:
      * @example
      * modelBuilder.entity(User).hasQueryFilter(u => u.isDeleted === false);

--- a/src/core/QueryFilter.ts
+++ b/src/core/QueryFilter.ts
@@ -39,7 +39,7 @@ export function compileQueryFilter(
         }
 
         // The operator string reaches SQL, so it goes through the same closed
-        // set as where() — filter conditions are data, not trusted SQL.
+        // set as where(). Filter conditions are data, not trusted SQL.
         // ModelBuilder.hasQueryFilter() validates at registration time too; this
         // check stays because metadata can also be populated directly.
         const operator = assertOperator(condition.operator, 'hasQueryFilter');
@@ -55,7 +55,7 @@ export function compileQueryFilter(
             : convert(value);
 
         // Placeholder numbering continues from however many parameters the
-        // preceding conditions actually bound — IN binds one per element and
+        // preceding conditions actually bound. IN binds one per element and
         // IS binds none, so "one placeholder per condition" is not safe here.
         const comparison = buildComparison(
             column.columnName,

--- a/src/core/expressions/PropertyCapture.ts
+++ b/src/core/expressions/PropertyCapture.ts
@@ -94,7 +94,7 @@ function createRecorder(): Recorder {
 
 /**
  * Result of re-running a selector against a root whose every property reads as
- * `undefined` — the "nullish probe" described in capture().
+ * `undefined`. The "nullish probe" described in capture().
  */
 interface NullishProbe {
     accesses: number;
@@ -142,14 +142,14 @@ function probeReturnedOnlyUndefined(returned: any, aliases?: string[]): boolean 
  *
  * 1. **Root-access count.** A faithful selector performs exactly one root
  *    property access per marker it returns, so a bare return with more than one
- *    access — or a projection with more accesses than alias entries — is
+ *    access. Or a projection with more accesses than alias entries. Is
  *    computing something. This is what catches ternaries and `&&`, whose
  *    condition operand costs an extra access. (Duplicate columns are fine:
  *    `{a: u.x, b: u.x}` is 2 accesses over 2 entries.)
  *
  * 2. **Nullish probe.** `||` and `??` short-circuit on their left operand, and a
  *    marker is always truthy and non-nullish, so the recorder never observes the
- *    right operand at all — no proxy trap can see it, and the access count is 1.
+ *    right operand at all. No proxy trap can see it, and the access count is 1.
  *    Re-running the selector against a root whose properties all read
  *    `undefined` forces the other branch: any extra root access, any thrown
  *    error, or any returned value that is not `undefined` (respectively an
@@ -160,7 +160,7 @@ function probeReturnedOnlyUndefined(returned: any, aliases?: string[]): boolean 
  * are required to be pure column pickers, so that is safe.
  *
  * RESIDUAL BLIND SPOT: a discarded operand that both costs no root access and
- * evaluates to `undefined` — `u => u.a || undefined`, `u => u.a ?? undefined`,
+ * evaluates to `undefined`. `u => u.a || undefined`, `u => u.a ?? undefined`,
  * or a closed-over variable that happens to hold `undefined`. Such an
  * expression is a semantic no-op (its result is always `u.a`), so resolving it
  * to column `a` is the correct answer anyway. Conversely, a selector that is

--- a/test/unit/IdentityMap.test.ts
+++ b/test/unit/IdentityMap.test.ts
@@ -253,12 +253,12 @@ describe('Identity Map (issue #5)', () => {
 });
 
 /**
- * Entities that enter tracking with a primary key already set — attach(),
- * update(), add() with an explicit id — must be identity-mapped too, or a
+ * Entities that enter tracking with a primary key already set. Attach(),
+ * update(), add() with an explicit id. Must be identity-mapped too, or a
  * later find() of the same key mints a second tracked instance (issue #5
  * through a third door).
  */
-describe('Identity Map — entities tracked without a round trip', () => {
+describe('Identity Map. Entities tracked without a round trip', () => {
     it('attach() then find(samePk) returns the attached instance', async () => {
         const { db, provider } = makeDb();
 
@@ -329,7 +329,7 @@ describe('Identity Map — entities tracked without a round trip', () => {
     });
 });
 
-describe('Identity Map — value-converted primary keys', () => {
+describe('Identity Map. Value-converted primary keys', () => {
     it('insert backfill and row mapping key the identity map identically', async () => {
         const { db, provider } = makeDb('postgresql');
 

--- a/test/unit/PropertyCapture.test.ts
+++ b/test/unit/PropertyCapture.test.ts
@@ -2,7 +2,7 @@ import "reflect-metadata";
 import { capture, captureAggregates, OpaqueReason, resolveColumn, resolvePropertyName } from '../../src/core/expressions/PropertyCapture';
 import { Entity, PrimaryKey, Column } from '../../src/decorators';
 
-describe('capture — single property', () => {
+describe('capture. Single property', () => {
     it('captures an arrow selector', () => {
         expect(capture((u: any) => u.name)).toEqual({ kind: 'property', path: 'name' });
     });
@@ -28,7 +28,7 @@ describe('capture — single property', () => {
     });
 });
 
-describe('capture — projections', () => {
+describe('capture. Projections', () => {
     it('captures an object-literal projection', () => {
         expect(capture((u: any) => ({ n: u.name, a: u.age })))
             .toEqual({ kind: 'projection', aliases: { n: 'name', a: 'age' } });
@@ -48,14 +48,14 @@ describe('capture — projections', () => {
     });
 });
 
-describe('capture — opaque detection', () => {
+describe('capture. Opaque detection', () => {
     // Each case's expected reason is asserted deterministically from the
     // implementation's control flow, not by running the code and copying
     // whatever came out:
     //  - string concatenation / template literal / arithmetic all force a
     //    coercion of a marker (ToPrimitive/ToString/ToNumber), which the
     //    marker's `get` trap flags via `coerced = true` before any value is
-    //    returned to `capture` — so these are always 'computed'.
+    //    returned to `capture`. So these are always 'computed'.
     //  - a throwing selector is always 'computed' because `capture`'s catch
     //    block hardcodes that reason regardless of why the throw happened.
     //  - `constant` and `array return` never touch the coercion path at all
@@ -65,7 +65,7 @@ describe('capture — opaque detection', () => {
     //    nor a plain object.
     //  - `the root itself` returns the root proxy unchanged. `pathOf(root)` is
     //    always undefined (only markers carry the PATH symbol), so `capture`
-    //    treats it as a plain-object projection candidate — but the target
+    //    treats it as a plain-object projection candidate. But the target
     //    object has no own properties, so the projection ends up with zero
     //    aliases, which is explicitly 'unsupported'.
     const cases: Array<[string, (u: any) => any, OpaqueReason]> = [
@@ -116,7 +116,7 @@ describe('capture — opaque detection', () => {
  */
 const FALLBACK = 'anonymous';
 
-describe('capture — short-circuit and branching selectors are opaque (I2)', () => {
+describe('capture. Short-circuit and branching selectors are opaque (I2)', () => {
     it.each([
         ['|| between two columns', (u: any) => u.nickname || u.name],
         ['?? between two columns', (u: any) => u.nickname ?? u.name],
@@ -144,7 +144,7 @@ describe('capture — short-circuit and branching selectors are opaque (I2)', ()
     it('is opaque when a reused marker hides a short-circuit', () => {
         // Compensating shape: aliasing a marker into a local means the extra
         // operand costs no additional root access, so the access count alone
-        // would let it through — the nullish probe is what catches it.
+        // would let it through. The nullish probe is what catches it.
         expect(capture((u: any) => {
             const nick = u.nickname;
             return { a: nick, b: nick || u.name };
@@ -173,7 +173,7 @@ describe('capture — short-circuit and branching selectors are opaque (I2)', ()
     });
 });
 
-describe('capture — safety', () => {
+describe('capture. Safety', () => {
     it('invokes the selector at most twice (normal pass + nullish probe)', () => {
         // The probe pass is what makes `||`/`??` detectable at all (see the I2
         // block above), so capture is no longer single-invocation. Selectors are
@@ -213,14 +213,14 @@ describe('captureAggregates', () => {
     });
 
     it('is opaque when a non-function argument is passed to an aggregate', () => {
-        // g.sum(5) must not be silently treated the same as g.sum() — a
+        // g.sum(5) must not be silently treated the same as g.sum(). A
         // non-function argument can't be resolved to a column path, so it
         // has to be flagged rather than guessed at.
         expect(captureAggregates((g: any) => ({ x: g.sum(5) })))
             .toEqual({ kind: 'opaque', reason: 'unsupported' });
     });
 
-    it('captures average — the documented IGrouping.average() method name', () => {
+    it('captures average. The documented IGrouping.average() method name', () => {
         // IGrouping.average() and the class's own @example blocks use
         // "average", not "avg". A capture that only recognized "avg" would
         // make the typed, documented public API silently unusable.
@@ -258,7 +258,7 @@ describe('captureAggregates', () => {
 
     it('is opaque for a genuinely unsupported selector shape', () => {
         // Not g.key, not a recognized aggregate call, not a plain object at
-        // all — a computed expression built from the group. This must stay
+        // all. A computed expression built from the group. This must stay
         // opaque; it is not something the g.key fix should start accepting.
         expect(captureAggregates((g: any) => g.key + 1))
             .toEqual({ kind: 'opaque', reason: 'unsupported' });

--- a/test/unit/QueryFilterCoverage.test.ts
+++ b/test/unit/QueryFilterCoverage.test.ts
@@ -11,7 +11,7 @@ import { SqlCaptureProvider, CaptureDialect } from '../mocks/SqlCaptureProvider'
  *
  * The original shipped bug was that count() silently ignored query filters.
  * This file pins that count() (and every other SQL read path) now includes the
- * filter — groupBy() included, since 2.2.0 closed that last gap.
+ * filter. GroupBy() included, since 2.2.0 closed that last gap.
  *
  * What is still NOT applied in SQL, and is pinned here as such: the legacy
  * predicate form of hasQueryFilter(), which runs in memory over materialized

--- a/test/unit/QueryFilterSql.test.ts
+++ b/test/unit/QueryFilterSql.test.ts
@@ -278,7 +278,7 @@ describe('query filters on raw SQL', () => {
 /**
  * Query filters that use the set/null operators (I4). compileQueryFilter numbers
  * its placeholders from `startIndex + compiled.params.length`, and QueryBuilder
- * hands it `this.params.length + 1` — both must account for an IN condition
+ * hands it `this.params.length + 1`. Both must account for an IN condition
  * consuming N parameters and an IS condition consuming none.
  *
  * Hand-traced (postgres), user conditions are emitted before filter clauses:

--- a/test/unit/SqlGeneration.test.ts
+++ b/test/unit/SqlGeneration.test.ts
@@ -46,7 +46,7 @@ class SgAccount {
 
 // Soft-delete-shaped entity for the set/null operators. @Column defaults the
 // column name to the LOWERCASED property name, so `deletedAt` maps to
-// `deletedat` — the assertions below spell the column, not the property.
+// `deletedat`. The assertions below spell the column, not the property.
 @Entity('sqlgen_docs')
 class SgDoc {
     @PrimaryKey()
@@ -604,7 +604,7 @@ describe('short-circuit selectors fall back to in-memory projection (I2)', () =>
         const results = await db.set(SgDoc).select(selector).toList();
 
         expect(provider.lastCall!.sql).toBe('SELECT * FROM sqlgen_docs');
-        // '' is falsy, so `||` yields 'live' — and `??` yields '' (only nullish
+        // '' is falsy, so `||` yields 'live'. And `??` yields '' (only nullish
         // falls through). Asserting both proves the selector ran in JS with real
         // values rather than being resolved to a single column at capture time.
         expect(results).toEqual([_label === '||' ? 'live' : '']);


### PR DESCRIPTION
Two things.

**Positioning.** Lands the part of #14 that is still accurate: who this library is for, how it differs from Drizzle, Kysely, Prisma and MikroORM, and the database support table with SQL Server and PostgreSQL as the focus. #14 also rewrote the README, CHANGELOG, TEST_SUMMARY, llms.txt and three test files, but all of that predates 2.2.0 and now describes behaviour that changed: it says query filters run in memory, the migration CLI does not work, and the suite has 232 tests. Those files were rewritten in #28. Closing #14 in favour of this.

**House style.** Removes every em dash and arrow glyph from tracked files, docs and source comments included.

534 tests pass, build clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified ORM capabilities, supported databases, audience guidance, feature claims, test coverage, and runtime limitations.
  - Improved security, contribution, issue-reporting, release, and example documentation.
  - Standardized wording, punctuation, formatting, and terminology across the README, changelog, guides, and comments.

- **Tests**
  - Updated test descriptions and explanatory comments for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->